### PR TITLE
Gboard_GoogleDialer_SysApps

### DIFF
--- a/14/gboard_as_sysapp.config
+++ b/14/gboard_as_sysapp.config
@@ -49,7 +49,7 @@ Core=0
 
 DigitalWellbeing=0
 GoogleMessages=0
-GoogleDialer=0
+GoogleDialer=2
 GoogleContacts=0
 CarrierServices=0
 GoogleClock=0
@@ -66,7 +66,7 @@ GoogleMaps=0
 GoogleLocationHistory=0
 GooglePhotos=0
 DeviceHealthServices=0
-GBoard=1
+GBoard=2
 GoogleCalendar=0
 GoogleKeep=0
 PlayGames=0


### PR DESCRIPTION
Update to install both Gboard and Google Dialer as system apps. Will NOT replace existing AOSP apps.